### PR TITLE
Make CertSrvH property types at ADCS.CertMod.Managed.Extensions public

### DIFF
--- a/ADCS.CertMod.Managed/Extensions/CertSrvH.cs
+++ b/ADCS.CertMod.Managed/Extensions/CertSrvH.cs
@@ -5,7 +5,7 @@ namespace ADCS.CertMod.Managed.Extensions;
 /// <summary>
 /// Contains useful CA constants.
 /// </summary>
-static class CertSrvH {
+public static class CertSrvH {
     public const Int32 PROPTYPE_LONG   = 1;
     public const Int32 PROPTYPE_DATE   = 2;
     public const Int32 PROPTYPE_BINARY = 3;


### PR DESCRIPTION
Make CertSrvH property types at ADCS.CertMod.Managed.Extensions public. Resolves #4 