### PR TITLE
Multi-threading support with object pool

### DIFF
--- a/ADCS.CertMod.Managed/ADCS.CertMod.Managed.csproj
+++ b/ADCS.CertMod.Managed/ADCS.CertMod.Managed.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,7 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <DocumentationFile>bin\Release\ADCS.CertMod.Managed.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
@@ -57,9 +57,11 @@
     <Compile Include="CertManageModule.cs" />
     <Compile Include="CertServerModule.cs" />
     <Compile Include="AdcsCrlReason.cs" />
+    <Compile Include="CertServerModulePool.cs" />
     <Compile Include="Exit\CertServerExitManaged.cs" />
     <Compile Include="GeneralFlags.cs" />
     <Compile Include="EnrollmentFlags.cs" />
+    <Compile Include="ObjectPool.cs" />
     <Compile Include="Policy\CertServerPolicyManaged.cs" />
     <Compile Include="PrivateKeyFlags.cs" />
     <Compile Include="Exit\CertExitBase.cs" />

--- a/ADCS.CertMod.Managed/CertServerModulePool.cs
+++ b/ADCS.CertMod.Managed/CertServerModulePool.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+using System;
+
+namespace ADCS.CertMod.Managed;
+
+/// <summary>
+/// Represents a pool for <see cref="CertServerModule"/> objects.
+/// </summary>
+/// <param name="size">Pool size. Must be between 1 and 63.</param>
+/// <param name="isPolicyModule">Specifies whether the module is policy or exit.</param>
+/// <param name="logger">An instance of custom implementation of <see cref="ILogWriter"/> interface.</param>
+class CertServerModulePool(Int32 size, Boolean isPolicyModule, ILogWriter logger)
+    : ObjectPool<CertServerModule>(size, () => isPolicyModule
+                                             ? CertServerModule.CreatePolicy(logger)
+                                             : CertServerModule.CreateExit(logger)) {
+    protected override void OnObjectReturn(CertServerModule obj) {
+        // finalize context in case caller forget to finalize. This method is idempotent, so safe to call multiple times.
+        obj.FinalizeContext();
+    }
+}

--- a/ADCS.CertMod.Managed/Exit/CertExitBase.cs
+++ b/ADCS.CertMod.Managed/Exit/CertExitBase.cs
@@ -50,8 +50,11 @@ public abstract class CertExitBase : ICertExit2 {
     public void Notify(ExitEvents ExitEvent, Int32 Context) {
         CertServerModule certServer = _pool.GetNext();
         certServer.InitializeEvent(Context, ExitEvent);
-        Notify(certServer, ExitEvent, Context);
-        _pool.Return(certServer);
+        try {
+            Notify(certServer, ExitEvent, Context);
+        } finally {
+            _pool.Return(certServer);
+        }
     }
     /// <inheritdoc cref="ICertExit.Notify" />
     /// <param name="certServer">An instance of <see cref="CertServerModule"/> class that allows to access request details.</param>

--- a/ADCS.CertMod.Managed/Exit/CertExitBase.cs
+++ b/ADCS.CertMod.Managed/Exit/CertExitBase.cs
@@ -6,23 +6,31 @@ namespace ADCS.CertMod.Managed.Exit;
 /// Represents base implementation of exit module.
 /// </summary>
 public abstract class CertExitBase : ICertExit2 {
+    const Int32 DEFAULT_POOL_SIZE = 32;
+
+    readonly CertServerModulePool _pool;
+
     /// <summary>
     /// Initializes a new instance of <strong>CertPolicyBase</strong> class.
     /// </summary>
     /// <param name="logger">An instance of custom implementation of <see cref="ILogWriter"/> interface.</param>
+    /// <param name="poolSize">Cert Server module pool size. Size must be between 1 and 63. Default is 32.</param>
     /// <exception cref="ArgumentNullException"><strong>logger</strong> parameter is null.</exception>
-    protected CertExitBase(ILogWriter logger) {
+    /// <exception cref="ArgumentOutOfRangeException"><strong>poolSize</strong> value is beyond 1-63 range.</exception>
+    protected CertExitBase(ILogWriter logger, Int32 poolSize = DEFAULT_POOL_SIZE) {
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        CertServer = CertServerModule.CreateExit(Logger);
+        _pool = new CertServerModulePool(poolSize, false, Logger);
     }
     /// <summary>
     /// Initializes a new instance of <strong>CertPolicyBase</strong> class.
     /// </summary>
     /// <param name="logFileName">Log file name to write stream.</param>
     /// <param name="logLevel">Initial log level.</param>
-    protected CertExitBase(String logFileName, LogLevel logLevel) {
+    /// <param name="poolSize">Cert Server module pool size. Size must be between 1 and 63. Default is 32.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><strong>poolSize</strong> value is beyond 1-63 range.</exception>
+    protected CertExitBase(String logFileName, LogLevel logLevel, Int32 poolSize = DEFAULT_POOL_SIZE) {
         Logger = new LogWriter(logFileName, logLevel);
-        CertServer = CertServerModule.CreateExit(Logger);
+        _pool = new CertServerModulePool(poolSize, false, Logger);
     }
 
     /// <summary>
@@ -30,16 +38,26 @@ public abstract class CertExitBase : ICertExit2 {
     /// </summary>
     protected ILogWriter Logger { get; }
     /// <summary>
-    /// Gets the communicator with Certification Authority.
+    /// <strong>Obsolete.</strong> This member is obsolete.
+    /// Use provided instance in <see cref="Notify(CertServerModule, ExitEvents, Int32)"/> overload.
     /// </summary>
+    [Obsolete("This member is not thread-safe. Use provided instance in 'Notify(CertServerModule, ExitEvents, Int32)' overload.", true)]
     protected CertServerModule CertServer { get; }
 
     /// <inheritdoc cref="ICertExit.Initialize" />
     public abstract ExitEvents Initialize(String strConfig);
     /// <inheritdoc cref="ICertExit.Notify" />
-    public virtual void Notify(ExitEvents ExitEvent, Int32 Context) {
-        CertServer.InitializeEvent(Context, ExitEvent);
+    public void Notify(ExitEvents ExitEvent, Int32 Context) {
+        CertServerModule certServer = _pool.GetNext();
+        certServer.InitializeEvent(Context, ExitEvent);
+        Notify(certServer, ExitEvent, Context);
+        _pool.Return(certServer);
     }
+    /// <inheritdoc cref="ICertExit.Notify" />
+    /// <param name="certServer">An instance of <see cref="CertServerModule"/> class that allows to access request details.</param>
+    /// <param name="ExitEvent"><inheritdoc cref="ICertExit.Initialize" path="/param[@name='ExitEvent']"/></param>
+    /// <param name="Context"><inheritdoc cref="ICertExit.Initialize" path="/param[@name='Context']"/></param>
+    protected abstract void Notify(CertServerModule certServer, ExitEvents ExitEvent, Int32 Context);
     /// <inheritdoc cref="ICertExit.GetDescription" />
     public abstract String GetDescription();
     /// <inheritdoc />

--- a/ADCS.CertMod.Managed/ObjectPool.cs
+++ b/ADCS.CertMod.Managed/ObjectPool.cs
@@ -1,0 +1,86 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+
+namespace ADCS.CertMod.Managed;
+
+/// <summary>
+/// Represents generic thread-safe object pool.
+/// </summary>
+/// <typeparam name="T">Pool object type.</typeparam>
+abstract class ObjectPool<T> where T : class {
+    // .NET upper limit is 64, however in STA apps, it is 63. Stick with the lowest supported.
+    // .NET limit: https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/mscorlib/system/threading/waithandle.cs#L41
+    // STA limit: https://github.com/dotnet/runtime/pull/1647
+    const Int32 POOL_UPPER_BOUND = 63;
+    readonly Mutex _hMutexAlterState;
+    readonly ManualResetEvent[] _events;
+    readonly T[] _pool;
+
+    /// <summary>
+    /// Initializes a new instance of <strong>ObjectPool</strong> from pool size and a delegate to create pool items.
+    /// </summary>
+    /// <param name="size">Pool size. Must be between 1 and 63.</param>
+    /// <param name="objectGenerator">An optional delegate to create pool items. If absent, a parameterless constructor is used instead.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Invalid pool size. Must be between 1 and 63.</exception>
+    protected ObjectPool(Int32 size, Func<T>? objectGenerator = null) {
+        if (size is < 1 or > POOL_UPPER_BOUND) {
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Invalid pool size. Must be between 1 and 63.");
+        }
+        _hMutexAlterState = new Mutex(false, null);
+        _events = new ManualResetEvent[size];
+        _pool = new T[size];
+        for (Int32 i = 0; i < _pool.Length; i++) {
+            _pool[i] = objectGenerator is null
+                ? Activator.CreateInstance<T>()
+                : objectGenerator();
+            _events[i] = new ManualResetEvent(true);
+        }
+    }
+
+    /// <summary>
+    /// Executes custom action before the object is returned to the pool.
+    /// </summary>
+    /// <param name="obj">Object being returned.</param>
+    protected virtual void OnObjectReturn(T obj) { }
+
+    /// <summary>
+    /// Retrieves next available instance from object pool.
+    /// </summary>
+    /// <returns></returns>
+    /// <remarks>After object is no longer in use, it MUST be released by calling <see cref="Return"/> method.</remarks>
+    public T GetNext() {
+        T? result = null;
+        if (_hMutexAlterState.WaitOne()) {
+            try {
+                // wait indefinitely
+                Int32 num = WaitHandle.WaitAny(_events, -1);
+                _events[num].Reset();
+                result = _pool[num];
+            } finally {
+                _hMutexAlterState.ReleaseMutex();
+            }
+        }
+
+        return result;
+    }
+    /// <summary>
+    /// Returns object to pool.
+    /// </summary>
+    /// <param name="obj">Object to return.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The object instance doesn't belong to current pool. Only objects created by <see cref="GetNext"/> method can be returned to the pool.
+    /// </exception>
+    public void Return(T obj) {
+        for (Int32 i = 0; i < _pool.Length; i++) {
+            if (ReferenceEquals(_pool[i], obj)) {
+                OnObjectReturn(_pool[i]);
+                _events[i].Set();
+
+                return;
+            }
+        }
+
+        throw new InvalidOperationException("The supplied object doesn't belong to current object pool.");
+    }
+}

--- a/ADCS.CertMod.Managed/Properties/AssemblyInfo.cs
+++ b/ADCS.CertMod.Managed/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("PKI Solutions LLC")]
 [assembly: AssemblyProduct("ADCS.CertMod.Managed")]
-[assembly: AssemblyCopyright("© PKI Solutions LLC, 2022-2023")]
+[assembly: AssemblyCopyright("© PKI Solutions LLC, 2022-2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
This PR contains a potential fix for issue #2.

In short, `CertServer` property in CertPolicyBase and CertExitBase is not thread-safe and it appears that `VerifyRequest` and `Notify` methods are called by CA asynchronously, which results in exception and CA service crash.

I've expressed my concerns about possible fixes that would:
- not overcomplicate policy and exit module development
- protect module from resource overconsumption
- reduce managed/unmanaged resource allocation and cleanup
- boost performance in multi-threading

This PR comes with a object pool of `CertServerModule` instances. The idea is inspired by Microsoft CLM policy module. Pool size is fixed and have some limits. Upper size limit is 63. At any given time, no more than 63 threads (or requests) can be processed in parallel. If there are more parallel calls, they are put in queue until any currently running thread finish. Entire pool is pre-created during policy module initialization, so extra resources are allocated only once.

I think it should greatly improve policy module performance over single-threded (with locks on single `CertServerModule` instance). However, due to the way how previous approach was implemented, it is not possible to fix race condition issue without introducing breaking change. These changes include:

- `CertPolicyBase.VerifyRequest(String, Int32, Int32, Int32)` and `CertExitBase.Notify(ExitEvents, Int32)` methods (that implement required interface) are no longer virtual and do not allow override.
- Instead, they call new abstract methods `CertPolicyBase.VerifyRequest(CertServerModule, PolicyModuleAction, Boolean)` and `CertExitBase.Notify(CertServerModule, ExitEvents, Int32)` respectively, where first parameter provides a thread-safe instance of `CertServerModule`.

This framework automatically acquire (and wait if necessary) and return object to the pool.